### PR TITLE
Hot_Fix_2024_03_25

### DIFF
--- a/src/components/AudioEditor.vue
+++ b/src/components/AudioEditor.vue
@@ -2581,7 +2581,7 @@
             let word = match[2];
             if (currentLength < match.index) {
               let addPart = text.substr(currentLength, match.index - currentLength);
-              if (closeBracketsRegex.test(addPart) || closeQuotesRegex.test(addPart)) {
+              if ((closeBracketsRegex.test(addPart) || closeQuotesRegex.test(addPart)) && annotations.length > 0) {
                 annotations[annotations.length - 1].id+= unescape(addPart.replace(/<\/?[^>]+?>/img, ''));
               } else {
                 word = addPart + word;

--- a/src/components/books/BookBlockPartView.vue
+++ b/src/components/books/BookBlockPartView.vue
@@ -4164,7 +4164,7 @@ Join subblocks?`,
         if (this.$refs.blockContent) {
           if (this.isSplittedBlock && this.blockPartIdx < this.block.parts.length - 1) {
             let hasWhitespaceStyle = (this.block && this.block.classes && ['verse', 'list', 'couplet'].includes(this.block.classes.whitespace) && /[\r\n]$/.test(this.blockPart.content));
-            if (/<br\s*\/?>|<\/ul>|<\/ol>$/.test(this.blockPart.content) || hasWhitespaceStyle) {
+            if (/<br\s*\/?>$|<\/ul>$|<\/ol>$/.test(this.blockPart.content) || hasWhitespaceStyle) {
               this.hasEndLinebreak = true;
               if (hasWhitespaceStyle) {
                 let textNode = this.$refs.blockContent.lastChild;


### PR DESCRIPTION
ILM-6570 | Superscript. The alignment gets broken after adding the superscript in the block
ILM-6568 | Superscript. The application stuck after pressing the superscript
ILM-6561 | Superscript. The alignment is broken in the block after setting the superscript
ILM-6557 | Audio editor. Audio editor is not opened if the block contains words that have the suggestions
ILM-6534 | Superscript. Publishing. The superscript is displayed as plain text in FFA apps.
ILM-6530 | Audio catalog. The audio file is not grey after aligning with the block
ILM-6520 | ILM Superscript turned to normal text in Reader